### PR TITLE
URL Cleanup

### DIFF
--- a/async-api-tests/build.gradle
+++ b/async-api-tests/build.gradle
@@ -9,10 +9,10 @@ configurations {
 repositories {
 	mavenLocal()
 	mavenCentral()
-	mavenRepo(name: "glassfish", urls: "http://download.java.net/maven/glassfish/")
-	mavenRepo(name: "java.net", urls: "http://download.java.net/maven/2")
-	mavenRepo(name: "codehaus", urls: "http://snapshots.repository.codehaus.org")
-	mavenRepo(name: "Spring Milestone", urls: "http://maven.springframework.org/milestone")
+	mavenRepo(name: "glassfish", urls: "https://download.java.net/maven/glassfish/")
+	mavenRepo(name: "java.net", urls: "https://download.java.net/maven/2")
+	mavenRepo(name: "codehaus", urls: "https://snapshots.repository.codehaus.org")
+	mavenRepo(name: "Spring Milestone", urls: "https://maven.springframework.org/milestone")
 }
 
 dependencies {

--- a/async-http-client/build.gradle
+++ b/async-http-client/build.gradle
@@ -10,10 +10,10 @@ configurations {
 repositories {
 	mavenLocal()
 	mavenCentral()
-	mavenRepo(name: "glassfish", urls: "http://download.java.net/maven/glassfish/")
-	mavenRepo(name: "java.net", urls: "http://download.java.net/maven/2")
-	mavenRepo(name: "codehaus", urls: "http://snapshots.repository.codehaus.org")
-	mavenRepo(name: "Spring Milestone", urls: "http://maven.springframework.org/milestone")
+	mavenRepo(name: "glassfish", urls: "https://download.java.net/maven/glassfish/")
+	mavenRepo(name: "java.net", urls: "https://download.java.net/maven/2")
+	mavenRepo(name: "codehaus", urls: "https://snapshots.repository.codehaus.org")
+	mavenRepo(name: "Spring Milestone", urls: "https://maven.springframework.org/milestone")
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://snapshots.repository.codehaus.org (UnknownHostException) migrated to:  
  https://snapshots.repository.codehaus.org ([https](https://snapshots.repository.codehaus.org) result UnknownHostException).
* http://download.java.net/maven/2 (301) migrated to:  
  https://download.java.net/maven/2 ([https](https://download.java.net/maven/2) result 404).
* http://download.java.net/maven/glassfish/ (301) migrated to:  
  https://download.java.net/maven/glassfish/ ([https](https://download.java.net/maven/glassfish/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).